### PR TITLE
Implement the CompilationUnit grammar

### DIFF
--- a/resources/FailCase1.java
+++ b/resources/FailCase1.java
@@ -1,4 +1,0 @@
-public abc FailCase1 {
-    int x = 1;
-    String str = "hello";
-}

--- a/resources/FailCase2.java
+++ b/resources/FailCase2.java
@@ -1,4 +1,0 @@
-claZZ FailCase2 {
-    int x = 1;
-    String str = "hello";
-}

--- a/resources/FailCase3.java
+++ b/resources/FailCase3.java
@@ -1,4 +1,0 @@
-special class FailCase3 {
-    int x = 1;
-    String str = "hello";
-}

--- a/resources/PassCase1.java
+++ b/resources/PassCase1.java
@@ -1,4 +1,0 @@
-
-public class PassCase1 {
-    int x = 1;
-}

--- a/resources/PassCase2.java
+++ b/resources/PassCase2.java
@@ -1,5 +1,0 @@
-
-public class PassCase2 {
-    int x = 1;
-    String str = "hello";
-}

--- a/resources/PassCase3.java
+++ b/resources/PassCase3.java
@@ -1,5 +1,0 @@
-
-class PassCase3 {
-    int x = 1;
-    String str = "hello";
-}

--- a/resources/test/TestCompilationUnit.java
+++ b/resources/test/TestCompilationUnit.java
@@ -1,0 +1,3 @@
+public class TestCompilationUnit {
+
+}

--- a/resources/test/TestCompilationUnit2.java
+++ b/resources/test/TestCompilationUnit2.java
@@ -1,0 +1,3 @@
+public abstract class TestCompilationUnit3 {
+
+}

--- a/resources/test/TestCompilationUnit3.java
+++ b/resources/test/TestCompilationUnit3.java
@@ -1,0 +1,3 @@
+class TestCompilationUnit2 {
+
+}

--- a/resources/test/TestCompilationUnitFail.java
+++ b/resources/test/TestCompilationUnitFail.java
@@ -1,0 +1,3 @@
+public clazz TestCompilationUnitFail2 {
+
+}

--- a/resources/test/TestCompilationUnitFail2.java
+++ b/resources/test/TestCompilationUnitFail2.java
@@ -1,0 +1,3 @@
+TestCompilationUnitFail {
+
+}

--- a/src/main/cup/parser.cup
+++ b/src/main/cup/parser.cup
@@ -20,24 +20,24 @@ terminal    LPAREN, RPAREN, LBRACE, RBRACE, LBRACK, RBRACK, SEMICOLON, COMMA, DO
 terminal    UNKNOWN;
 
     
-non terminal      compilationUnit, typeDeclaration, classDeclaration;
-non terminal      normalClassDeclaration, classModifiers, classModifier, classBody;
+non terminal      CompilationUnit, TypeDeclaration, ClassDeclaration;
+non terminal      NormalClassDeclaration, ClassModifiers, ClassModifier, ClassBody;
 
-compilationUnit ::= typeDeclaration;
+CompilationUnit ::= TypeDeclaration;
 
-typeDeclaration ::= classDeclaration;
+TypeDeclaration ::= ClassDeclaration;
 
-classDeclaration ::= normalClassDeclaration;
+ClassDeclaration ::= NormalClassDeclaration;
 
-normalClassDeclaration ::= classModifiers CLASS IDENTIFIER classBody;
+NormalClassDeclaration ::= ClassModifiers CLASS IDENTIFIER ClassBody;
 
-classModifiers ::= classModifier classModifiers
+ClassModifiers ::= ClassModifier ClassModifiers
                   | /* empty */
                   ;
                   
-classModifier ::= PUBLIC | PROTECTED | PRIVATE | ABSTRACT | STATIC | FINAL | STRICTFP;
+ClassModifier ::= PUBLIC | PROTECTED | PRIVATE | ABSTRACT | STATIC | FINAL | STRICTFP;
 
-classBody ::= LBRACE /* zero or more ClassBodyDeclaration not yet implemented */ RBRACE;
+ClassBody ::= LBRACE /* zero or more ClassBodyDeclaration not yet implemented */ RBRACE;
 
 
 

--- a/src/main/cup/parser.cup
+++ b/src/main/cup/parser.cup
@@ -2,41 +2,44 @@ package org.ifn660.jflexer;
 
 import java_cup.runtime.*;
 
-terminal 	INT, BOOLEAN, CHAR, CONST, DOUBLE, FLOAT, LONG, SHORT;
-terminal 	ABSTRACT, CLASS, SUPER, INTERFACE, EXTENDS, IMPLEMENTS;
+terminal    INT, BOOLEAN, CHAR, CONST, DOUBLE, FLOAT, LONG, SHORT;
+terminal    ABSTRACT, CLASS, SUPER, INTERFACE, EXTENDS, IMPLEMENTS;
 terminal    VOID, NULL, STATIC;
-terminal 	IF, ELSE, DO, WHILE, FOR, CASE, SWITCH, BREAK;
+terminal    IF, ELSE, DO, WHILE, FOR, CASE, SWITCH, BREAK;
 terminal    RETURN;
-terminal 	PUBLIC, PRIVATE, PROTECTED;
-terminal 	ASSERT, BYTE;
+terminal    PUBLIC, PRIVATE, PROTECTED;
+terminal    ASSERT, BYTE;
 terminal    CONTINUE, DEFAULT, ENUM, FINAL, FINALLY, GOTO;
 terminal    IMPORT, INSTANCEOF, NATIVE, NEW, PACKAGE, STRICTFP;
 terminal    SYNCHRONIZED, THIS, TRANSIENT, VOLATILE;
 terminal    CATCH, TRY, THROW, THROWS;
-terminal 	IDENTIFIER;
-terminal 	EQ, EQEQ, PLUS;
-terminal 	INTEGER_LITERAL, STRING_LITERAL;
-terminal 	LPAREN, RPAREN, LBRACE, RBRACE, LBRACK, RBRACK, SEMICOLON, COMMA, DOT;
-terminal 	UNKNOWN;
+terminal    IDENTIFIER;
+terminal    EQ, EQEQ, PLUS;
+terminal    INTEGER_LITERAL, STRING_LITERAL;
+terminal    LPAREN, RPAREN, LBRACE, RBRACE, LBRACK, RBRACK, SEMICOLON, COMMA, DOT;
+terminal    UNKNOWN;
 
     
-non terminal expr, class_expr, int_assign_expr, str_assign_expr;
-non terminal eof;
-non terminal class_content;
-non terminal access_modifier;
+non terminal      compilationUnit, typeDeclaration, classDeclaration;
+non terminal      normalClassDeclaration, classModifiers, classModifier, classBody;
 
+compilationUnit ::= typeDeclaration;
 
+typeDeclaration ::= classDeclaration;
 
-class_expr ::= access_modifier CLASS IDENTIFIER LBRACE class_content RBRACE;
+classDeclaration ::= normalClassDeclaration;
 
-access_modifier ::= PUBLIC
+normalClassDeclaration ::= classModifiers CLASS IDENTIFIER classBody;
+
+classModifiers ::= classModifier classModifiers
                   | /* empty */
                   ;
+                  
+classModifier ::= PUBLIC | PROTECTED | PRIVATE | ABSTRACT | STATIC | FINAL | STRICTFP;
 
-class_content ::= int_assign_expr class_content
-                  | str_assign_expr class_content
-                  | /* empty */
-                  ;
+classBody ::= LBRACE /* zero or more ClassBodyDeclaration not yet implemented */ RBRACE;
 
-int_assign_expr ::= INT IDENTIFIER EQ INTEGER_LITERAL SEMICOLON;
-str_assign_expr ::= IDENTIFIER IDENTIFIER EQ STRING_LITERAL SEMICOLON;
+
+
+
+

--- a/src/test/java/org/ifn660/jflexer/TestCases.java
+++ b/src/test/java/org/ifn660/jflexer/TestCases.java
@@ -10,13 +10,13 @@ public class TestCases {
     
     @Test
     public void testPass() throws Exception {
-        String[] filenames = {"PassCase1.java", "PassCase2.java", "PassCase3.java"};
+        String[] filenames = {"TestCompilationUnit.java", "TestCompilationUnit2.java", "TestCompilationUnit3.java"};
         
         final int expectedPass = filenames.length;
         int actualPass  = 0;
         
         for (String filename : filenames) {
-            parser p = new parser(new Lexer(new FileReader("resources/" + filename)));
+            parser p = new parser(new Lexer(new FileReader("resources/test/" + filename)));
             p.parse();
             actualPass++;
         }
@@ -26,14 +26,14 @@ public class TestCases {
     
     @Test
     public void testFail() {
-        String[] filenames = {"FailCase1.java", "FailCase2.java", "FailCase3.java"};
+        String[] filenames = {"TestCompilationUnitFail.java", "TestCompilationUnitFail2.java"};
         
         final int expectedFail = filenames.length;
         int actualFail = 0;
         
         for (String filename : filenames) {
             try {
-                parser p = new parser(new Lexer(new FileReader("resources/" + filename)));
+                parser p = new parser(new Lexer(new FileReader("resources/test/" + filename)));
                 p.parse();
                 Assert.fail("Grammar fail with " + filename);
             } catch (Exception e) {


### PR DESCRIPTION
Hi Everyone,

I have implemented the grammar starting from compilationUnit -> classBody, tested with test case below

```
public class TestCompilationUnit {

}
```

and

```
public abstract class TestCompilationUnit3 {

}
```

as well as some more test cases in https://github.com/vthai/JFlexer/tree/vinh/compilation_unit/resources/test

Please review and let me know if this is good to go into master branch
